### PR TITLE
Update repository URLs and improve error handling for address generation

### DIFF
--- a/epixnet.py
+++ b/epixnet.py
@@ -77,7 +77,7 @@ def displayErrorMessage(err, error_log_path):
     res = ctypes.windll.user32.MessageBoxW(0, err_title, "EpixNet error", MB_YESNOCANCEL | MB_ICONEXCLAIMATION)
     if res == ID_YES:
         import webbrowser
-        report_url = "https://github.com/epixnet/epixnet/issues/new"
+        report_url = "https://github.com/EpixZone/EpixNet/issues/new"
         webbrowser.open(report_url)
     if res in [ID_YES, ID_NO]:
         subprocess.Popen(['notepad.exe', error_log_path])

--- a/plugins/Sidebar/SidebarPlugin.py
+++ b/plugins/Sidebar/SidebarPlugin.py
@@ -803,6 +803,9 @@ class UiWebsocketPlugin(object):
         privatekey = CryptEpix.hdPrivatekey(self.user.master_seed, address_index)
         privatekey_address = CryptEpix.privatekeyToAddress(privatekey)
 
+        if not privatekey_address or privatekey_address is False:
+            return {"error": "Failed to generate valid address from privatekey"}
+
         if privatekey_address == self.site.address:
             site_data["privatekey"] = privatekey
             self.user.save()

--- a/src/Actions.py
+++ b/src/Actions.py
@@ -95,6 +95,8 @@ class Actions:
         else:
             privatekey = CryptEpix.newPrivatekey()
             address = CryptEpix.privatekeyToAddress(privatekey)
+            if not address or address is False:
+                raise Exception("Failed to generate valid site address from privatekey")
         logging.info("----------------------------------------------------------------------")
         logging.info("Site private key: %s" % privatekey)
         logging.info("                  !!! ^ Save it now, required to modify the site ^ !!!")

--- a/src/Crypt/CryptBitcoin.py
+++ b/src/Crypt/CryptBitcoin.py
@@ -57,7 +57,12 @@ def newSeed():
 
 def hdPrivatekey(seed, child):
     # Too large child id could cause problems
-    privatekey_bin = sslcurve.derive_child(seed.encode(), child % 100000000)
+    # Convert hex seed string to binary
+    if isinstance(seed, str):
+        seed_bin = bytes.fromhex(seed)
+    else:
+        seed_bin = seed
+    privatekey_bin = sslcurve.derive_child(seed_bin, child % 100000000)
     return sslcurve.private_to_wif(privatekey_bin).decode()
 
 

--- a/src/Crypt/CryptEpix.py
+++ b/src/Crypt/CryptEpix.py
@@ -28,7 +28,12 @@ def newSeed():
 
 def hdPrivatekey(seed, child):
     # Too large child id could cause problems
-    privatekey_bin = sslcurve.derive_child(seed.encode(), child % 100000000)
+    # Convert hex seed string to binary
+    if isinstance(seed, str):
+        seed_bin = bytes.fromhex(seed)
+    else:
+        seed_bin = seed
+    privatekey_bin = sslcurve.derive_child(seed_bin, child % 100000000)
     return sslcurve.private_to_wif(privatekey_bin).decode()
 
 
@@ -38,10 +43,10 @@ def privatekeyToAddress(privatekey):  # Return Epix address from private key
             privatekey_bin = bytes.fromhex(privatekey)
         else:
             privatekey_bin = sslcurve.wif_to_private(privatekey.encode())
-        
-        # Get public key from private key
+
+        # Get public key from private key (uncompressed format)
         public_key = sslcurve.private_to_public(privatekey_bin)
-        
+
         # Convert to Epix address using bech32 encoding
         return publicKeyToAddress(public_key)
     except Exception:  # Invalid privatekey

--- a/src/Test/TestUser.py
+++ b/src/Test/TestUser.py
@@ -6,9 +6,9 @@ from Crypt import CryptEpix
 @pytest.mark.usefixtures("resetSettings")
 class TestUser:
     def testAddress(self, user):
-        assert user.master_address == "15E5rhcAUD69WbiYsYARh4YHJ4sLm2JEyc"
-        address_index = 1458664252141532163166741013621928587528255888800826689784628722366466547364755811
-        assert user.getAddressAuthIndex("15E5rhcAUD69WbiYsYARh4YHJ4sLm2JEyc") == address_index
+        assert user.master_address == "epix16jha5q3qvr7fgldrgem4x5ju8vwd78d3lwawtn"
+        address_index = 14199856986777972317416200829214867103927393370315628508069949862373673319704318642080835749710491251822
+        assert user.getAddressAuthIndex("epix16jha5q3qvr7fgldrgem4x5ju8vwd78d3lwawtn") == address_index
 
     # Re-generate privatekey based on address_index
     def testNewSite(self, user):
@@ -24,27 +24,33 @@ class TestUser:
 
     def testAuthAddress(self, user):
         # Auth address without Cert
-        auth_address = user.getAuthAddress("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr")
-        assert auth_address == "epix1pp7m6d33p0tq99zyz6j42vnka6h4d5rk7f7hga"
-        auth_privatekey = user.getAuthPrivatekey("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr")
+        test_site_address = "epix1test0000000000000000000000000000000000"
+        auth_address = user.getAuthAddress(test_site_address)
+        assert auth_address == "epix19mqssu8uf40xfuzfczlxrxauus9k8r5jaznrgf"
+        auth_privatekey = user.getAuthPrivatekey(test_site_address)
         assert CryptEpix.privatekeyToAddress(auth_privatekey) == auth_address
 
     def testCert(self, user):
-        cert_auth_address = user.getAuthAddress("epix1xauthduuyn63k6kj54jzgp4l8nnjlhrsyaku8c")  # Add site to user's registry
+        cert_site_address = "epix1xauthduuyn63k6kj54jzgp4l8nnjlhrsyaku8c"
+        test_site_address = "epix1test0000000000000000000000000000000000"
+
+        cert_auth_address = user.getAuthAddress(cert_site_address)  # Add site to user's registry
+        assert cert_auth_address == "epix1lxfgsrns0uex5gtlvn3ta74adnam2cwjvpet4q"
+
         # Add cert
         user.addCert(cert_auth_address, "zeroid.bit", "faketype", "fakeuser", "fakesign")
-        user.setCert("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr", "zeroid.bit")
+        user.setCert(test_site_address, "zeroid.bit")
 
         # By using certificate the auth address should be same as the certificate provider
-        assert user.getAuthAddress("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr") == cert_auth_address
-        auth_privatekey = user.getAuthPrivatekey("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr")
+        assert user.getAuthAddress(test_site_address) == cert_auth_address
+        auth_privatekey = user.getAuthPrivatekey(test_site_address)
         assert CryptEpix.privatekeyToAddress(auth_privatekey) == cert_auth_address
 
         # Test delete site data
-        assert "1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr" in user.sites
-        user.deleteSiteData("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr")
-        assert "1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr" not in user.sites
+        assert test_site_address in user.sites
+        user.deleteSiteData(test_site_address)
+        assert test_site_address not in user.sites
 
         # Re-create add site should generate normal, unique auth_address
-        assert not user.getAuthAddress("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr") == cert_auth_address
-        assert user.getAuthAddress("1EU1tbG9oC1A8jz2ouVwGZyQ5asrNsE4Vr") == "epix1pp7m6d33p0tq99zyz6j42vnka6h4d5rk7f7hga"
+        assert not user.getAuthAddress(test_site_address) == cert_auth_address
+        assert user.getAuthAddress(test_site_address) == "epix19mqssu8uf40xfuzfczlxrxauus9k8r5jaznrgf"

--- a/termux.sh
+++ b/termux.sh
@@ -7,7 +7,7 @@ VENV_SCRIPT="start-venv.sh"
 if [[ -d "$REPO_DIR" ]]; then
     (cd "$REPO_DIR" && git pull --ff-only)
 else
-    git clone https://github.com/epixnet/epixnet "$REPO_DIR"
+    git clone https://github.com/EpixZone/EpixNet "$REPO_DIR"
 fi
 
 pkg update -y


### PR DESCRIPTION
This pull request introduces several reliability improvements and test updates for EpixNet, focusing on stricter address validation, enhanced error handling, and migration of test data to the new Bech32 address format. The changes help prevent invalid address generation, improve error reporting, and ensure tests use the updated address format.

### Reliability and Validation Improvements
* Added checks in `CryptEpix.hdPrivatekey`, `User.__init__`, `User.generateAuthAddress`, `User.getNewSiteData`, and related methods to ensure addresses generated from seeds and private keys are valid; exceptions are raised if invalid addresses are encountered. [[1]](diffhunk://#diff-1ed52b56b4c04d7f5e1d05f807389fd05b6472bd7158d6540949a7dc6c14917cR22-R31) [[2]](diffhunk://#diff-1ed52b56b4c04d7f5e1d05f807389fd05b6472bd7158d6540949a7dc6c14917cR62-R75) [[3]](diffhunk://#diff-1ed52b56b4c04d7f5e1d05f807389fd05b6472bd7158d6540949a7dc6c14917cR110-R111) [[4]](diffhunk://#diff-94d04f3efd279ada3c4b73b307014d9df78571a028c44aee0e45e6a3f28a617bR806-R808) [[5]](diffhunk://#diff-4105df549f1c1c6db2017992dc2d5e1d870a89be2c397754ea41b0075b569a01R98-R99)
* Improved type safety in `User.getAddressAuthIndex` by validating the address input type and raising a `TypeError` when necessary.

### Test Data and Address Format Migration
* Updated all test fixtures and test cases to use Bech32 Epix addresses instead of legacy formats, ensuring consistency with the new address standard. [[1]](diffhunk://#diff-fddab912f17afbff6f14827d8d78ede981869e7af8eb7486ebad65493058d3e8L9-R11) [[2]](diffhunk://#diff-fddab912f17afbff6f14827d8d78ede981869e7af8eb7486ebad65493058d3e8L27-R56) [[3]](diffhunk://#diff-ae1b84540c2d22374b87c75101c23a2013ebc3276f5a80aba7869dc929538ecaR136-R163) [[4]](diffhunk://#diff-ae1b84540c2d22374b87c75101c23a2013ebc3276f5a80aba7869dc929538ecaL171-R181)

### Error Handling and Reporting
* Improved error reporting in `displayErrorMessage` and updated the GitHub issue URL to the new repository.
* Enhanced cleanup routines in test configuration to use `pathlib.Path` for directory management and added exception handling to prevent errors during cleanup from affecting test runs. [[1]](diffhunk://#diff-ae1b84540c2d22374b87c75101c23a2013ebc3276f5a80aba7869dc929538ecaL75-R77) [[2]](diffhunk://#diff-ae1b84540c2d22374b87c75101c23a2013ebc3276f5a80aba7869dc929538ecaR136-R163) [[3]](diffhunk://#diff-ae1b84540c2d22374b87c75101c23a2013ebc3276f5a80aba7869dc929538ecaL246-R256)

### Cryptographic Key Handling
* Updated `hdPrivatekey` functions in both `CryptBitcoin.py` and `CryptEpix.py` to correctly convert hex seed strings to binary before deriving child keys, improving compatibility and correctness. [[1]](diffhunk://#diff-9d2ffb94ce7a9e098817eed5568643bec5c632bfa6bb8009be268fb7d7162d47L60-R65) [[2]](diffhunk://#diff-cc261a80d209dd0894f6cb8ac46a877d5ca3e6cb15393babfb7615caf862904eL31-R36)

### Repository and Clone Script Updates
* Changed the default GitHub repository URLs in scripts and error messages to point to the new `EpixZone/EpixNet` repository. [[1]](diffhunk://#diff-ae617cd2817b0d554a5af76b581dc7889dd7d7dc1bc1d775a660dc1ed2e999e0L10-R10) [[2]](diffhunk://#diff-72745bf8a0650e7f37b783cc65c7fb90e6e3e4985485a41e89d5fb6d6deeac40L80-R80)