### PR TITLE
Notifications

### DIFF
--- a/plugins/Notification/NotificationPlugin.py
+++ b/plugins/Notification/NotificationPlugin.py
@@ -144,6 +144,19 @@ class UiWebsocketPlugin(object):
                         query_params = map(helper.sqlquote, params)
                         query = query.replace(":params", ",".join(query_params))
 
+                    # Replace {xid_directory} placeholder with user's directory for this site
+                    if "{xid_directory}" in query:
+                        xid_dir = self.user.getUserDirectory(address)
+                        if not xid_dir:
+                            continue
+                        query = query.replace("{xid_directory}", xid_dir)
+
+                    # Replace {last_seen} with dismiss timestamp so queries can filter
+                    dismissed = site_data.get("notification_dismissed", {})
+                    last_seen = dismissed.get(name, 0)
+                    if "{last_seen}" in query:
+                        query = query.replace("{last_seen}", str(int(last_seen)))
+
                     res = site.storage.query(query)
                     row = next(res, None)
                     if row:
@@ -151,10 +164,6 @@ class UiWebsocketPlugin(object):
                         count = row.get("count", row.get("COUNT(*)", 0))
                     else:
                         count = 0
-
-                    # Apply dismiss filter if set
-                    dismissed = site_data.get("notification_dismissed", {})
-                    last_seen = dismissed.get(name, 0)
 
                     result_entry = {
                         "site": address,
@@ -215,7 +224,17 @@ class UiWebsocketPlugin(object):
         site_data = self.user.getSiteData(site_address)
         if "notification_dismissed" not in site_data:
             site_data["notification_dismissed"] = {}
-        site_data["notification_dismissed"][name] = int(time.time())
+        site_data["notification_dismissed"][name] = int(time.time() * 1000)
+        self.user.save()
+        self.response(to, "ok")
+
+    # Dismiss own site's notifications (callable from within the site iframe, no admin needed)
+    def actionNotificationDismissSelf(self, to, name):
+        site_address = self.site.address
+        site_data = self.user.getSiteData(site_address)
+        if "notification_dismissed" not in site_data:
+            site_data["notification_dismissed"] = {}
+        site_data["notification_dismissed"][name] = int(time.time() * 1000)
         self.user.save()
         self.response(to, "ok")
 

--- a/plugins/Notification/NotificationPlugin.py
+++ b/plugins/Notification/NotificationPlugin.py
@@ -196,20 +196,19 @@ class UiWebsocketPlugin(object):
         prev_total = _last_totals.get(user_key, 0)
         _last_totals[user_key] = new_total
 
-        if new_total > prev_total and prev_total >= 0:
+        if new_total > prev_total:
             try:
                 import main
                 announce = getattr(main.actions, "announce", None)
                 if announce:
-                    # Build toast message from results with counts
                     parts = []
                     for r in results:
                         if r.get("count", 0) > 0:
                             parts.append("%s %s" % (r["count"], r.get("title", r.get("name", ""))))
                     if parts:
-                        announce("\n".join(parts), title="EpixNet")
-            except Exception:
-                pass  # Trayicon plugin may not be loaded
+                        announce("\n".join(parts), title="")
+            except Exception as err:
+                self.log.error("Notification toast error: %s" % Debug.formatException(err))
 
         return self.response(to, {
             "results": results,

--- a/plugins/Notification/NotificationPlugin.py
+++ b/plugins/Notification/NotificationPlugin.py
@@ -165,6 +165,15 @@ class UiWebsocketPlugin(object):
                     else:
                         count = 0
 
+                    # Subtract "seen" baseline from site's private user settings
+                    # Sites save notification_seen.{name} via userSetSettings when visited
+                    site_settings = site_data.get("settings", {})
+                    if site_settings:
+                        seen = site_settings.get("notification_seen", {})
+                        baseline = seen.get(name, 0)
+                        if baseline and count:
+                            count = max(0, count - baseline)
+
                     result_entry = {
                         "site": address,
                         "title": title,

--- a/plugins/Notification/NotificationPlugin.py
+++ b/plugins/Notification/NotificationPlugin.py
@@ -1,0 +1,229 @@
+import re
+import os
+import time
+
+from Config import config
+from Plugin import PluginManager
+from Debug import Debug
+from util import helper
+from util.Flag import flag
+
+
+plugin_dir = os.path.dirname(__file__)
+media_dir = plugin_dir + "/media"
+
+# Track previous notification totals per user to detect increases for tray toast
+_last_totals = {}
+
+
+@PluginManager.registerTo("UiRequest")
+class UiRequestPlugin(object):
+    def actionUiMedia(self, path):
+        if path == "/uimedia/all.js" or path == "/uimedia/all.css":
+            # First yield the original file and header
+            body_generator = super(UiRequestPlugin, self).actionUiMedia(path)
+            for part in body_generator:
+                yield part
+
+            # Append notification plugin media
+            ext = re.match(".*(js|css)$", path).group(1)
+            plugin_media_file = "%s/all.%s" % (media_dir, ext)
+            if config.debug:
+                from Debug import DebugMedia
+                DebugMedia.merge(plugin_media_file)
+            if ext == "js":
+                yield open(plugin_media_file).read().encode("utf8")
+            else:
+                for part in self.actionFile(plugin_media_file, send_header=False):
+                    yield part
+        else:
+            for part in super(UiRequestPlugin, self).actionUiMedia(path):
+                yield part
+
+
+@PluginManager.registerTo("UiWebsocket")
+class UiWebsocketPlugin(object):
+    # Subscribe to notification queries for a site
+    def actionNotificationSubscribe(self, to, subscriptions):
+        self.user.setNotificationSubscriptions(self.site.address, subscriptions)
+        self.user.save()
+        self.response(to, "ok")
+
+    # List current notification subscriptions for the current site
+    def actionNotificationList(self, to):
+        notifications = self.user.sites.get(self.site.address, {}).get("notifications", {})
+        self.response(to, notifications)
+
+    # Mute/unmute notifications globally or per-site
+    # muted: bool — the mute state to set
+    # site_address: optional — if provided, mute only that site; otherwise mute all
+    @flag.admin
+    def actionNotificationMute(self, to, muted, site_address=None):
+        muted = bool(muted)
+        if site_address:
+            # Per-site mute
+            site_data = self.user.getSiteData(site_address)
+            site_data["notification_muted"] = muted
+        else:
+            # Global mute
+            self.user.settings["notification_muted"] = muted
+        self.user.save()
+        self.response(to, "ok")
+
+    # Get current mute settings
+    @flag.admin
+    def actionNotificationMuteStatus(self, to):
+        global_muted = self.user.settings.get("notification_muted", False)
+
+        # Collect per-site mute states for sites that have notification subscriptions
+        site_mutes = {}
+        for address, site_data in list(self.user.sites.items()):
+            if not site_data.get("notifications"):
+                continue
+            site_mutes[address] = site_data.get("notification_muted", False)
+
+        self.response(to, {
+            "global_muted": global_muted,
+            "site_mutes": site_mutes
+        })
+
+    # Query notification counts across all subscribed sites
+    @flag.admin
+    def actionNotificationQuery(self, to):
+        from Site import SiteManager
+
+        # Check global mute
+        if self.user.settings.get("notification_muted", False):
+            return self.response(to, {
+                "results": [],
+                "num": 0,
+                "sites": 0,
+                "taken": 0,
+                "muted": True
+            })
+
+        results = []
+        total_s = time.time()
+        num_sites = 0
+
+        for address, site_data in list(self.user.sites.items()):
+            subscriptions = site_data.get("notifications")
+            if not subscriptions:
+                continue
+            if type(subscriptions) is not dict:
+                self.log.debug("Invalid notifications for site %s" % address)
+                continue
+
+            # Check per-site mute
+            if site_data.get("notification_muted", False):
+                continue
+
+            site = SiteManager.site_manager.get(address)
+            if not site or not site.storage.has_db:
+                continue
+
+            num_sites += 1
+            content_json = site.content_manager.contents.get("content.json", {})
+            title = content_json.get("title", address)
+            # Icons: site declares "notification_icons" dict in content.json
+            # Maps notification name to icon path: {"new_mail": "img/notif-mail.png", ...}
+            icons = content_json.get("notification_icons", {})
+            if not isinstance(icons, dict):
+                icons = {}
+
+            for name, query_set in subscriptions.items():
+                s = time.time()
+                try:
+                    query_raw, params = query_set
+                    if not re.match(r'^SELECT\s', query_raw, re.IGNORECASE):
+                        self.log.error("Notification query must start with SELECT: %s" % name)
+                        continue
+
+                    query = query_raw
+                    if params:
+                        query_params = map(helper.sqlquote, params)
+                        query = query.replace(":params", ",".join(query_params))
+
+                    res = site.storage.query(query)
+                    row = next(res, None)
+                    if row:
+                        row = dict(row)
+                        count = row.get("count", row.get("COUNT(*)", 0))
+                    else:
+                        count = 0
+
+                    # Apply dismiss filter if set
+                    dismissed = site_data.get("notification_dismissed", {})
+                    last_seen = dismissed.get(name, 0)
+
+                    result_entry = {
+                        "site": address,
+                        "title": title,
+                        "name": name,
+                        "count": count,
+                        "last_seen": last_seen,
+                        "taken": round(time.time() - s, 3)
+                    }
+                    # Look up per-notification icon from the site's icon map
+                    icon = icons.get(name)
+                    if icon:
+                        result_entry["icon"] = icon
+                    results.append(result_entry)
+                except Exception as err:
+                    self.log.error("%s notification query %s error: %s" % (address, name, Debug.formatException(err)))
+                    results.append({
+                        "site": address,
+                        "title": title,
+                        "name": name,
+                        "count": 0,
+                        "error": str(err)
+                    })
+
+                time.sleep(0.001)
+
+        # Fire OS tray toast if notification count increased
+        new_total = sum(r.get("count", 0) for r in results)
+        user_key = getattr(self.user, "master_address", "default")
+        prev_total = _last_totals.get(user_key, 0)
+        _last_totals[user_key] = new_total
+
+        if new_total > prev_total and prev_total >= 0:
+            try:
+                import main
+                announce = getattr(main.actions, "announce", None)
+                if announce:
+                    # Build toast message from results with counts
+                    parts = []
+                    for r in results:
+                        if r.get("count", 0) > 0:
+                            parts.append("%s %s" % (r["count"], r.get("title", r.get("name", ""))))
+                    if parts:
+                        announce("\n".join(parts), title="EpixNet")
+            except Exception:
+                pass  # Trayicon plugin may not be loaded
+
+        return self.response(to, {
+            "results": results,
+            "num": len(results),
+            "sites": num_sites,
+            "taken": round(time.time() - total_s, 3)
+        })
+
+    # Dismiss (mark as seen) notifications for a site
+    @flag.admin
+    def actionNotificationDismiss(self, to, site_address, name):
+        site_data = self.user.getSiteData(site_address)
+        if "notification_dismissed" not in site_data:
+            site_data["notification_dismissed"] = {}
+        site_data["notification_dismissed"][name] = int(time.time())
+        self.user.save()
+        self.response(to, "ok")
+
+
+@PluginManager.registerTo("User")
+class UserPlugin(object):
+    def setNotificationSubscriptions(self, address, subscriptions):
+        site_data = self.getSiteData(address)
+        site_data["notifications"] = subscriptions
+        self.save()
+        return site_data

--- a/plugins/Notification/NotificationPlugin.py
+++ b/plugins/Notification/NotificationPlugin.py
@@ -165,11 +165,6 @@ class UiWebsocketPlugin(object):
                     else:
                         count = 0
 
-                    # Subtract dismissed count baseline so only new items show
-                    dismissed_counts = site_data.get("notification_dismissed_count", {})
-                    baseline = dismissed_counts.get(name, 0)
-                    count = max(0, count - baseline)
-
                     result_entry = {
                         "site": address,
                         "title": title,
@@ -223,42 +218,10 @@ class UiWebsocketPlugin(object):
         })
 
     def _dismissNotification(self, site_address, name):
-        """Snapshot current query count as baseline so only new items trigger alerts."""
-        from Site import SiteManager
-
         site_data = self.user.getSiteData(site_address)
         if "notification_dismissed" not in site_data:
             site_data["notification_dismissed"] = {}
         site_data["notification_dismissed"][name] = int(time.time() * 1000)
-
-        # Store current raw count as baseline
-        if "notification_dismissed_count" not in site_data:
-            site_data["notification_dismissed_count"] = {}
-        subscriptions = site_data.get("notifications", {})
-        query_set = subscriptions.get(name)
-        if query_set:
-            try:
-                site = SiteManager.site_manager.get(site_address)
-                if site and site.storage.has_db:
-                    query_raw, params = query_set
-                    query = query_raw
-                    if params:
-                        query_params = map(helper.sqlquote, params)
-                        query = query.replace(":params", ",".join(query_params))
-                    if "{xid_directory}" in query:
-                        xid_dir = self.user.getUserDirectory(site_address)
-                        if xid_dir:
-                            query = query.replace("{xid_directory}", xid_dir)
-                    if "{last_seen}" in query:
-                        query = query.replace("{last_seen}", "0")
-                    res = site.storage.query(query)
-                    row = next(res, None)
-                    if row:
-                        row = dict(row)
-                        site_data["notification_dismissed_count"][name] = row.get("count", row.get("COUNT(*)", 0))
-            except Exception as err:
-                self.log.error("Dismiss count snapshot error: %s" % err)
-
         self.user.save()
 
     # Dismiss (mark as seen) notifications for a site

--- a/plugins/Notification/NotificationPlugin.py
+++ b/plugins/Notification/NotificationPlugin.py
@@ -165,6 +165,11 @@ class UiWebsocketPlugin(object):
                     else:
                         count = 0
 
+                    # Subtract dismissed count baseline so only new items show
+                    dismissed_counts = site_data.get("notification_dismissed_count", {})
+                    baseline = dismissed_counts.get(name, 0)
+                    count = max(0, count - baseline)
+
                     result_entry = {
                         "site": address,
                         "title": title,
@@ -217,24 +222,54 @@ class UiWebsocketPlugin(object):
             "taken": round(time.time() - total_s, 3)
         })
 
-    # Dismiss (mark as seen) notifications for a site
-    @flag.admin
-    def actionNotificationDismiss(self, to, site_address, name):
+    def _dismissNotification(self, site_address, name):
+        """Snapshot current query count as baseline so only new items trigger alerts."""
+        from Site import SiteManager
+
         site_data = self.user.getSiteData(site_address)
         if "notification_dismissed" not in site_data:
             site_data["notification_dismissed"] = {}
         site_data["notification_dismissed"][name] = int(time.time() * 1000)
+
+        # Store current raw count as baseline
+        if "notification_dismissed_count" not in site_data:
+            site_data["notification_dismissed_count"] = {}
+        subscriptions = site_data.get("notifications", {})
+        query_set = subscriptions.get(name)
+        if query_set:
+            try:
+                site = SiteManager.site_manager.get(site_address)
+                if site and site.storage.has_db:
+                    query_raw, params = query_set
+                    query = query_raw
+                    if params:
+                        query_params = map(helper.sqlquote, params)
+                        query = query.replace(":params", ",".join(query_params))
+                    if "{xid_directory}" in query:
+                        xid_dir = self.user.getUserDirectory(site_address)
+                        if xid_dir:
+                            query = query.replace("{xid_directory}", xid_dir)
+                    if "{last_seen}" in query:
+                        query = query.replace("{last_seen}", "0")
+                    res = site.storage.query(query)
+                    row = next(res, None)
+                    if row:
+                        row = dict(row)
+                        site_data["notification_dismissed_count"][name] = row.get("count", row.get("COUNT(*)", 0))
+            except Exception as err:
+                self.log.error("Dismiss count snapshot error: %s" % err)
+
         self.user.save()
+
+    # Dismiss (mark as seen) notifications for a site
+    @flag.admin
+    def actionNotificationDismiss(self, to, site_address, name):
+        self._dismissNotification(site_address, name)
         self.response(to, "ok")
 
     # Dismiss own site's notifications (callable from within the site iframe, no admin needed)
     def actionNotificationDismissSelf(self, to, name):
-        site_address = self.site.address
-        site_data = self.user.getSiteData(site_address)
-        if "notification_dismissed" not in site_data:
-            site_data["notification_dismissed"] = {}
-        site_data["notification_dismissed"][name] = int(time.time() * 1000)
-        self.user.save()
+        self._dismissNotification(self.site.address, name)
         self.response(to, "ok")
 
 

--- a/plugins/Notification/__init__.py
+++ b/plugins/Notification/__init__.py
@@ -1,0 +1,1 @@
+from . import NotificationPlugin

--- a/plugins/Notification/media/Notification.css
+++ b/plugins/Notification/media/Notification.css
@@ -1,0 +1,32 @@
+
+/* ---- Notification.css ---- */
+
+
+.fixbutton-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background-color: #e74c3c;
+    color: #fff;
+    border-radius: 10px;
+    min-width: 18px;
+    height: 18px;
+    font-size: 11px;
+    font-weight: bold;
+    line-height: 18px;
+    text-align: center;
+    padding: 0 4px;
+    z-index: 1000;
+    pointer-events: none;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    display: none;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    box-sizing: border-box;
+    animation: badge-pop 0.3s ease-out;
+}
+
+@keyframes badge-pop {
+    0% { transform: scale(0); }
+    70% { transform: scale(1.15); }
+    100% { transform: scale(1); }
+}

--- a/plugins/Notification/media/Notification.css
+++ b/plugins/Notification/media/Notification.css
@@ -4,29 +4,30 @@
 
 .fixbutton-badge {
     position: absolute;
-    top: -4px;
-    right: -4px;
+    top: 20px;
+    left: 50%;
+    transform: translate(-50%, -50%);
     background-color: #e74c3c;
     color: #fff;
-    border-radius: 10px;
-    min-width: 18px;
-    height: 18px;
-    font-size: 11px;
+    border-radius: 2px;
+    min-width: 14px;
+    height: 14px;
+    font-size: 9px;
     font-weight: bold;
-    line-height: 18px;
-    text-align: center;
-    padding: 0 4px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0 2px;
     z-index: 1000;
     pointer-events: none;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-    display: none;
     box-shadow: 0 1px 3px rgba(0,0,0,0.3);
     box-sizing: border-box;
     animation: badge-pop 0.3s ease-out;
 }
 
 @keyframes badge-pop {
-    0% { transform: scale(0); }
-    70% { transform: scale(1.15); }
-    100% { transform: scale(1); }
+    0% { transform: translate(-50%, -50%) scale(0); }
+    70% { transform: translate(-50%, -50%) scale(1.15); }
+    100% { transform: translate(-50%, -50%) scale(1); }
 }

--- a/plugins/Notification/media/Notification.js
+++ b/plugins/Notification/media/Notification.js
@@ -1,0 +1,173 @@
+
+/* ---- Notification.js ---- */
+
+
+(function() {
+  var NotificationBadge;
+
+  NotificationBadge = (function() {
+    function NotificationBadge(wrapper) {
+      this.wrapper = wrapper;
+      this.badge = null;
+      this.results = [];
+      this.muted = false;
+      this.poll_interval = 60000;
+      this.poll_timer = null;
+      this.initialized = false;
+
+      this.createBadge();
+      this.hookWebsocket();
+      this.waitForConnection();
+    }
+
+    NotificationBadge.prototype.log = function() {
+      var args;
+      args = 1 <= arguments.length ? [].slice.call(arguments, 0) : [];
+      return console.log.apply(console, ["[NotificationBadge]"].concat(args));
+    };
+
+    NotificationBadge.prototype.createBadge = function() {
+      this.badge = document.createElement("span");
+      this.badge.className = "fixbutton-badge";
+      this.badge.style.display = "none";
+      var fixbutton = document.querySelector(".fixbutton");
+      if (fixbutton) {
+        fixbutton.appendChild(this.badge);
+      }
+    };
+
+    NotificationBadge.prototype.waitForConnection = function() {
+      var _this = this;
+      // Wait until websocket is connected before first query
+      var check = function() {
+        if (_this.wrapper.ws && _this.wrapper.ws.connected) {
+          _this.query();
+          _this.startPolling();
+        } else {
+          setTimeout(check, 1000);
+        }
+      };
+      setTimeout(check, 2000);
+    };
+
+    NotificationBadge.prototype.hookWebsocket = function() {
+      var _this = this;
+      var original = this.wrapper.handleMessageWebsocket;
+      this.wrapper.handleMessageWebsocket = function(message) {
+        // When any site has a file_done event, re-query notifications
+        if (message.cmd === "setSiteInfo" && message.params && message.params.event) {
+          if (message.params.event[0] === "file_done") {
+            // Debounce: wait a moment for DB to update, then re-query
+            if (_this._file_done_timer) clearTimeout(_this._file_done_timer);
+            _this._file_done_timer = setTimeout(function() {
+              _this.query();
+            }, 3000);
+          }
+        }
+        return original.call(_this.wrapper, message);
+      };
+    };
+
+    NotificationBadge.prototype.startPolling = function() {
+      var _this = this;
+      if (this.poll_timer) clearInterval(this.poll_timer);
+      this.poll_timer = setInterval(function() {
+        _this.query();
+      }, this.poll_interval);
+    };
+
+    NotificationBadge.prototype.query = function() {
+      var _this = this;
+      if (!this.wrapper.ws || !this.wrapper.ws.connected) return;
+
+      this.wrapper.ws.cmd("notificationQuery", {}, function(res) {
+        if (!res || res.error) {
+          _this.log("Query error:", res);
+          return;
+        }
+        _this.muted = !!res.muted;
+        _this.results = res.results || [];
+        _this.updateBadge();
+      });
+    };
+
+    NotificationBadge.prototype.updateBadge = function() {
+      var total = 0;
+      for (var i = 0; i < this.results.length; i++) {
+        var r = this.results[i];
+        if (r.count && r.count > 0) {
+          total += r.count;
+        }
+      }
+
+      if (total > 0) {
+        this.badge.textContent = total > 99 ? "99+" : total.toString();
+        this.badge.style.display = "block";
+        this.badge.title = this.buildTooltip();
+      } else {
+        this.badge.style.display = "none";
+        this.badge.title = "";
+      }
+    };
+
+    NotificationBadge.prototype.buildTooltip = function() {
+      var parts = [];
+      for (var i = 0; i < this.results.length; i++) {
+        var r = this.results[i];
+        if (r.count && r.count > 0) {
+          parts.push(r.count + " " + (r.title || r.name));
+        }
+      }
+      return parts.join("\n");
+    };
+
+    // Get full icon URL for a result entry (for dashboard rendering)
+    // Site declares "notification_icons": {"name": "img/icon.png"} in content.json
+    // Full URL: /{site_address}/{icon_path}
+    NotificationBadge.prototype.getIconUrl = function(result) {
+      if (result.icon) {
+        return "/" + result.site + "/" + result.icon;
+      }
+      return null;
+    };
+
+    // Get results with count > 0 (convenience for dashboard)
+    NotificationBadge.prototype.getActiveResults = function() {
+      var active = [];
+      for (var i = 0; i < this.results.length; i++) {
+        if (this.results[i].count > 0) {
+          active.push(this.results[i]);
+        }
+      }
+      return active;
+    };
+
+    // Mute all notifications globally, or mute a specific site
+    // site_address: optional — omit to mute/unmute globally
+    NotificationBadge.prototype.mute = function(muted, site_address, cb) {
+      var _this = this;
+      var params = { muted: muted };
+      if (site_address) params.site_address = site_address;
+      this.wrapper.ws.cmd("notificationMute", params, function(res) {
+        _this.query();
+        if (cb) cb(res);
+      });
+    };
+
+    // Get full mute status (global + per-site map)
+    NotificationBadge.prototype.getMuteStatus = function(cb) {
+      this.wrapper.ws.cmd("notificationMuteStatus", {}, cb);
+    };
+
+    return NotificationBadge;
+  })();
+
+  // Initialize after wrapper is ready (same pattern as Sidebar)
+  var wrapper = window.wrapper;
+  if (wrapper) {
+    setTimeout(function() {
+      window.notificationBadge = new NotificationBadge(wrapper);
+    }, 800);
+  }
+
+}).call(this);

--- a/plugins/Notification/media/Notification.js
+++ b/plugins/Notification/media/Notification.js
@@ -101,8 +101,8 @@
       }
 
       if (total > 0) {
-        this.badge.textContent = total > 99 ? "99+" : total.toString();
-        this.badge.style.display = "block";
+        this.badge.textContent = total > 99 ? "\u221E" : total.toString();
+        this.badge.style.display = "flex";
         this.badge.title = this.buildTooltip();
       } else {
         this.badge.style.display = "none";

--- a/plugins/Notification/media/all.css
+++ b/plugins/Notification/media/all.css
@@ -1,0 +1,32 @@
+
+/* ---- Notification.css ---- */
+
+
+.fixbutton-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background-color: #e74c3c;
+    color: #fff;
+    border-radius: 10px;
+    min-width: 18px;
+    height: 18px;
+    font-size: 11px;
+    font-weight: bold;
+    line-height: 18px;
+    text-align: center;
+    padding: 0 4px;
+    z-index: 1000;
+    pointer-events: none;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    display: none;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    box-sizing: border-box;
+    animation: badge-pop 0.3s ease-out;
+}
+
+@keyframes badge-pop {
+    0% { transform: scale(0); }
+    70% { transform: scale(1.15); }
+    100% { transform: scale(1); }
+}

--- a/plugins/Notification/media/all.css
+++ b/plugins/Notification/media/all.css
@@ -4,29 +4,30 @@
 
 .fixbutton-badge {
     position: absolute;
-    top: -4px;
-    right: -4px;
+    top: 20px;
+    left: 50%;
+    transform: translate(-50%, -50%);
     background-color: #e74c3c;
     color: #fff;
-    border-radius: 10px;
-    min-width: 18px;
-    height: 18px;
-    font-size: 11px;
+    border-radius: 2px;
+    min-width: 14px;
+    height: 14px;
+    font-size: 9px;
     font-weight: bold;
-    line-height: 18px;
-    text-align: center;
-    padding: 0 4px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0 2px;
     z-index: 1000;
     pointer-events: none;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-    display: none;
     box-shadow: 0 1px 3px rgba(0,0,0,0.3);
     box-sizing: border-box;
     animation: badge-pop 0.3s ease-out;
 }
 
 @keyframes badge-pop {
-    0% { transform: scale(0); }
-    70% { transform: scale(1.15); }
-    100% { transform: scale(1); }
+    0% { transform: translate(-50%, -50%) scale(0); }
+    70% { transform: translate(-50%, -50%) scale(1.15); }
+    100% { transform: translate(-50%, -50%) scale(1); }
 }

--- a/plugins/Notification/media/all.js
+++ b/plugins/Notification/media/all.js
@@ -1,0 +1,173 @@
+
+/* ---- Notification.js ---- */
+
+
+(function() {
+  var NotificationBadge;
+
+  NotificationBadge = (function() {
+    function NotificationBadge(wrapper) {
+      this.wrapper = wrapper;
+      this.badge = null;
+      this.results = [];
+      this.muted = false;
+      this.poll_interval = 60000;
+      this.poll_timer = null;
+      this.initialized = false;
+
+      this.createBadge();
+      this.hookWebsocket();
+      this.waitForConnection();
+    }
+
+    NotificationBadge.prototype.log = function() {
+      var args;
+      args = 1 <= arguments.length ? [].slice.call(arguments, 0) : [];
+      return console.log.apply(console, ["[NotificationBadge]"].concat(args));
+    };
+
+    NotificationBadge.prototype.createBadge = function() {
+      this.badge = document.createElement("span");
+      this.badge.className = "fixbutton-badge";
+      this.badge.style.display = "none";
+      var fixbutton = document.querySelector(".fixbutton");
+      if (fixbutton) {
+        fixbutton.appendChild(this.badge);
+      }
+    };
+
+    NotificationBadge.prototype.waitForConnection = function() {
+      var _this = this;
+      // Wait until websocket is connected before first query
+      var check = function() {
+        if (_this.wrapper.ws && _this.wrapper.ws.connected) {
+          _this.query();
+          _this.startPolling();
+        } else {
+          setTimeout(check, 1000);
+        }
+      };
+      setTimeout(check, 2000);
+    };
+
+    NotificationBadge.prototype.hookWebsocket = function() {
+      var _this = this;
+      var original = this.wrapper.handleMessageWebsocket;
+      this.wrapper.handleMessageWebsocket = function(message) {
+        // When any site has a file_done event, re-query notifications
+        if (message.cmd === "setSiteInfo" && message.params && message.params.event) {
+          if (message.params.event[0] === "file_done") {
+            // Debounce: wait a moment for DB to update, then re-query
+            if (_this._file_done_timer) clearTimeout(_this._file_done_timer);
+            _this._file_done_timer = setTimeout(function() {
+              _this.query();
+            }, 3000);
+          }
+        }
+        return original.call(_this.wrapper, message);
+      };
+    };
+
+    NotificationBadge.prototype.startPolling = function() {
+      var _this = this;
+      if (this.poll_timer) clearInterval(this.poll_timer);
+      this.poll_timer = setInterval(function() {
+        _this.query();
+      }, this.poll_interval);
+    };
+
+    NotificationBadge.prototype.query = function() {
+      var _this = this;
+      if (!this.wrapper.ws || !this.wrapper.ws.connected) return;
+
+      this.wrapper.ws.cmd("notificationQuery", {}, function(res) {
+        if (!res || res.error) {
+          _this.log("Query error:", res);
+          return;
+        }
+        _this.muted = !!res.muted;
+        _this.results = res.results || [];
+        _this.updateBadge();
+      });
+    };
+
+    NotificationBadge.prototype.updateBadge = function() {
+      var total = 0;
+      for (var i = 0; i < this.results.length; i++) {
+        var r = this.results[i];
+        if (r.count && r.count > 0) {
+          total += r.count;
+        }
+      }
+
+      if (total > 0) {
+        this.badge.textContent = total > 99 ? "99+" : total.toString();
+        this.badge.style.display = "block";
+        this.badge.title = this.buildTooltip();
+      } else {
+        this.badge.style.display = "none";
+        this.badge.title = "";
+      }
+    };
+
+    NotificationBadge.prototype.buildTooltip = function() {
+      var parts = [];
+      for (var i = 0; i < this.results.length; i++) {
+        var r = this.results[i];
+        if (r.count && r.count > 0) {
+          parts.push(r.count + " " + (r.title || r.name));
+        }
+      }
+      return parts.join("\n");
+    };
+
+    // Get full icon URL for a result entry (for dashboard rendering)
+    // Site declares "notification_icons": {"name": "img/icon.png"} in content.json
+    // Full URL: /{site_address}/{icon_path}
+    NotificationBadge.prototype.getIconUrl = function(result) {
+      if (result.icon) {
+        return "/" + result.site + "/" + result.icon;
+      }
+      return null;
+    };
+
+    // Get results with count > 0 (convenience for dashboard)
+    NotificationBadge.prototype.getActiveResults = function() {
+      var active = [];
+      for (var i = 0; i < this.results.length; i++) {
+        if (this.results[i].count > 0) {
+          active.push(this.results[i]);
+        }
+      }
+      return active;
+    };
+
+    // Mute all notifications globally, or mute a specific site
+    // site_address: optional — omit to mute/unmute globally
+    NotificationBadge.prototype.mute = function(muted, site_address, cb) {
+      var _this = this;
+      var params = { muted: muted };
+      if (site_address) params.site_address = site_address;
+      this.wrapper.ws.cmd("notificationMute", params, function(res) {
+        _this.query();
+        if (cb) cb(res);
+      });
+    };
+
+    // Get full mute status (global + per-site map)
+    NotificationBadge.prototype.getMuteStatus = function(cb) {
+      this.wrapper.ws.cmd("notificationMuteStatus", {}, cb);
+    };
+
+    return NotificationBadge;
+  })();
+
+  // Initialize after wrapper is ready (same pattern as Sidebar)
+  var wrapper = window.wrapper;
+  if (wrapper) {
+    setTimeout(function() {
+      window.notificationBadge = new NotificationBadge(wrapper);
+    }, 800);
+  }
+
+}).call(this);

--- a/plugins/Trayicon/TrayiconPlugin.py
+++ b/plugins/Trayicon/TrayiconPlugin.py
@@ -88,8 +88,29 @@ class ActionsPlugin(object):
         self.main = main
         self.console = False
 
-        # Load icon image
         icon_path = os.path.join(plugin_dir, "trayicon.ico")
+
+        # Set AppUserModelID so Windows toasts are attributed to EpixNet
+        # instead of "Python". The friendly display name and icon are
+        # registered once per user under HKCU so the toast shows "EpixNet".
+        if sys.platform == "win32":
+            aumid = "EpixZone.EpixNet"
+            try:
+                import winreg
+                key_path = r"Software\Classes\AppUserModelId\%s" % aumid
+                with winreg.CreateKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+                    winreg.SetValueEx(key, "DisplayName", 0, winreg.REG_SZ, "EpixNet")
+                    if os.path.exists(icon_path):
+                        winreg.SetValueEx(key, "IconUri", 0, winreg.REG_SZ, icon_path)
+            except Exception as err:
+                print("Trayicon plugin: failed to register AUMID display name: %s" % err)
+            try:
+                import ctypes
+                ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(aumid)
+            except Exception as err:
+                print("Trayicon plugin: failed to set AppUserModelID: %s" % err)
+
+        # Load icon image
         try:
             icon_image = Image.open(icon_path)
         except Exception as err:
@@ -228,10 +249,24 @@ class ActionsPlugin(object):
         import webbrowser
         webbrowser.open(url, new=0)
 
-    def announce(self, message, title="EpixNet"):
+    def announce(self, message, title=""):
         """Show an OS notification toast via the tray icon."""
+        icon = getattr(self, "icon", None)
+        if icon is None or not getattr(icon, "visible", False):
+            return
         try:
-            self.icon.notify(message, title)
+            # Bypass pystray's title fallback (which uses self.title) so
+            # toasts don't show a redundant EpixNet heading above the body.
+            if sys.platform == "win32" and hasattr(icon, "_message"):
+                from pystray import _win32 as pystray_win32
+                icon._message(
+                    pystray_win32.win32.NIM_MODIFY,
+                    pystray_win32.win32.NIF_INFO,
+                    szInfo=message,
+                    szInfoTitle=title or "",
+                )
+            else:
+                icon.notify(message, title or None)
         except Exception as err:
             print("Trayicon announce error: %s" % err)
 

--- a/plugins/Trayicon/TrayiconPlugin.py
+++ b/plugins/Trayicon/TrayiconPlugin.py
@@ -63,13 +63,26 @@ class ActionsPlugin(object):
     def main(self):
         try:
             import pystray
+            import pystray._base
             from PIL import Image
         except ImportError as err:
             print("Trayicon plugin: pystray or Pillow not installed (%s), skipping tray icon." % err)
             super(ActionsPlugin, self).main()
             return
 
-        import gevent.threadpool
+        # pystray runs on a real OS thread and uses queue.Queue for signaling.
+        # gevent.monkey.patch_all() replaces queue.Queue with a cooperative
+        # version that only works inside a gevent hub, which causes LoopExit
+        # when pystray's setup thread blocks on .get(). Swap in the unpatched
+        # stdlib Queue on pystray's own queue module reference.
+        try:
+            import gevent.monkey
+            real_queue_cls = gevent.monkey.get_original("queue", "Queue")
+            pystray._base.queue.Queue = real_queue_cls
+        except Exception as err:
+            print("Trayicon plugin: failed to restore stdlib queue.Queue: %s" % err)
+
+        import threading
         import main
 
         self.main = main
@@ -164,21 +177,27 @@ class ActionsPlugin(object):
             except Exception as err:
                 print("Error removing trayicon: %s" % err)
 
-        self.quit_servers_event = gevent.threadpool.ThreadResult(
-            lambda res: gevent.spawn_later(0.1, self.quitServers), gevent.threadpool.get_hub(), lambda: True
-        )  # Fix gevent thread switch error
+        import gevent
+        hub = gevent.get_hub()
+        self._quit_async = hub.loop.async_()
+        self._quit_async.start(lambda: gevent.spawn_later(0.1, self.quitServers))
 
-        # Run pystray in a real thread (not gevent compatible)
-        gevent.threadpool.start_new_thread(self.icon.run, ())
+        # Run pystray in a real OS thread (pystray is not gevent compatible)
+        self._icon_thread = threading.Thread(target=self.icon.run, name="Trayicon", daemon=True)
+        self._icon_thread.start()
         super(ActionsPlugin, self).main()
         try:
             self.icon.stop()
         except Exception:
             pass
+        try:
+            self._quit_async.stop()
+        except Exception:
+            pass
 
     def _on_quit(self, icon, item):
         self.icon.stop()
-        self.quit_servers_event.set(True)
+        self._quit_async.send()
 
     def _on_toggle_console(self, icon, item):
         if self.console:
@@ -198,8 +217,12 @@ class ActionsPlugin(object):
         self._on_quit(None, None)
 
     def quitServers(self):
-        self.main.ui_server.stop()
-        self.main.file_server.stop()
+        ui_server = getattr(self.main, "ui_server", None)
+        file_server = getattr(self.main, "file_server", None)
+        if ui_server is not None:
+            ui_server.stop()
+        if file_server is not None:
+            file_server.stop()
 
     def opensite(self, url):
         import webbrowser
@@ -213,21 +236,30 @@ class ActionsPlugin(object):
             print("Trayicon announce error: %s" % err)
 
     def titleIp(self):
-        title = "IP: %s " % ", ".join(self.main.file_server.ip_external_list)
-        if any(self.main.file_server.port_opened):
+        file_server = getattr(self.main, "file_server", None)
+        if file_server is None:
+            return "IP: - "
+        title = "IP: %s " % ", ".join(file_server.ip_external_list)
+        if any(file_server.port_opened):
             title += _["(active)"]
         else:
             title += _["(passive)"]
         return title
 
     def titleConnections(self):
-        title = _["Connections: %s"] % len(self.main.file_server.connections)
+        file_server = getattr(self.main, "file_server", None)
+        if file_server is None:
+            return _["Connections: %s"] % 0
+        title = _["Connections: %s"] % len(file_server.connections)
         return title
 
     def titleTransfer(self):
+        file_server = getattr(self.main, "file_server", None)
+        if file_server is None:
+            return _["Received: %.2f MB | Sent: %.2f MB"] % (0.0, 0.0)
         title = _["Received: %.2f MB | Sent: %.2f MB"] % (
-            float(self.main.file_server.bytes_recv) / 1024 / 1024,
-            float(self.main.file_server.bytes_sent) / 1024 / 1024
+            float(file_server.bytes_recv) / 1024 / 1024,
+            float(file_server.bytes_sent) / 1024 / 1024
         )
         return title
 

--- a/plugins/Trayicon/TrayiconPlugin.py
+++ b/plugins/Trayicon/TrayiconPlugin.py
@@ -15,67 +15,187 @@ if "_" not in locals():
     _ = Translate(plugin_dir + "/languages/")
 
 
+def _has_console():
+    """Check if a console window is available (Windows only)."""
+    if sys.platform != "win32":
+        return False
+    try:
+        import ctypes
+        return ctypes.windll.kernel32.GetConsoleWindow() != 0
+    except Exception:
+        return False
+
+
+def _hide_console():
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        ctypes.windll.user32.ShowWindow(ctypes.windll.kernel32.GetConsoleWindow(), 0)
+    except Exception:
+        pass
+
+
+def _show_console():
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        ctypes.windll.user32.ShowWindow(ctypes.windll.kernel32.GetConsoleWindow(), 1)
+    except Exception:
+        pass
+
+
+def _get_startup_folder():
+    """Get Windows Startup folder path. Returns None on non-Windows."""
+    if sys.platform != "win32":
+        return None
+    try:
+        from .lib import winfolders
+        return winfolders.get(winfolders.STARTUP)
+    except Exception:
+        return None
+
+
 @PluginManager.registerTo("Actions")
 class ActionsPlugin(object):
 
     def main(self):
-        global notificationicon, winfolders
-        from .lib import notificationicon, winfolders
+        try:
+            import pystray
+            from PIL import Image
+        except ImportError as err:
+            print("Trayicon plugin: pystray or Pillow not installed (%s), skipping tray icon." % err)
+            super(ActionsPlugin, self).main()
+            return
+
         import gevent.threadpool
         import main
 
         self.main = main
-
-        icon = notificationicon.NotificationIcon(
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), 'trayicon.ico'),
-            "EpixNet %s" % config.version
-        )
-        self.icon = icon
-
         self.console = False
+
+        # Load icon image
+        icon_path = os.path.join(plugin_dir, "trayicon.ico")
+        try:
+            icon_image = Image.open(icon_path)
+        except Exception as err:
+            print("Trayicon plugin: Failed to load icon %s: %s" % (icon_path, err))
+            super(ActionsPlugin, self).main()
+            return
+
+        ui_ip = config.ui_ip if config.ui_ip != "*" else "127.0.0.1"
+        if ":" in ui_ip:
+            ui_ip = "[" + ui_ip + "]"
+        self._epixnet_url = "http://%s:%s/%s" % (ui_ip, config.ui_port, config.homepage)
+
+        # Build menu
+        menu_items = [
+            pystray.MenuItem(
+                lambda item: self.titleIp(),
+                None, enabled=False
+            ),
+            pystray.MenuItem(
+                lambda item: self.titleConnections(),
+                None, enabled=False
+            ),
+            pystray.MenuItem(
+                lambda item: self.titleTransfer(),
+                None, enabled=False
+            ),
+        ]
+
+        # Console toggle (Windows only)
+        if _has_console():
+            menu_items.append(
+                pystray.MenuItem(
+                    lambda item: _["Show console window"],
+                    self._on_toggle_console,
+                    checked=lambda item: self.console
+                )
+            )
+
+        # Autorun toggle (Windows only)
+        if sys.platform == "win32":
+            menu_items.append(
+                pystray.MenuItem(
+                    lambda item: _["Start EpixNet when Windows starts"],
+                    self._on_toggle_autorun,
+                    checked=lambda item: self.isAutorunEnabled()
+                )
+            )
+
+        menu_items.append(pystray.Menu.SEPARATOR)
+        menu_items.append(pystray.MenuItem(
+            _["EpixNet X"],
+            lambda icon, item: self.opensite("https://x.com/zone_epix")
+        ))
+        menu_items.append(pystray.MenuItem(
+            _["EpixNet Github"],
+            lambda icon, item: self.opensite("https://github.com/EpixZone/EpixNet")
+        ))
+        menu_items.append(pystray.MenuItem(
+            _["Report bug/request feature"],
+            lambda icon, item: self.opensite("https://github.com/EpixZone/EpixNet/issues")
+        ))
+        menu_items.append(pystray.Menu.SEPARATOR)
+        menu_items.append(pystray.MenuItem(
+            _["!Open EpixNet"].lstrip("!"),
+            lambda icon, item: self.opensite(self._epixnet_url),
+            default=True
+        ))
+        menu_items.append(pystray.Menu.SEPARATOR)
+        menu_items.append(pystray.MenuItem(
+            _["Quit"],
+            self._on_quit
+        ))
+
+        self.icon = pystray.Icon(
+            "epixnet",
+            icon=icon_image,
+            title="EpixNet %s" % config.version,
+            menu=pystray.Menu(*menu_items)
+        )
 
         @atexit.register
         def hideIcon():
             try:
-                icon.die()
+                self.icon.stop()
             except Exception as err:
                 print("Error removing trayicon: %s" % err)
 
-        ui_ip = config.ui_ip if config.ui_ip != "*" else "127.0.0.1"
-
-        if ":" in ui_ip:
-            ui_ip = "[" + ui_ip + "]"
-
-        icon.items = [
-            (self.titleIp, False),
-            (self.titleConnections, False),
-            (self.titleTransfer, False),
-            (self.titleConsole, self.toggleConsole),
-            (self.titleAutorun, self.toggleAutorun),
-            "--",
-            (_["EpixNet X"], lambda: self.opensite("https://x.com/zone_epix")),
-            (_["EpixNet Github"], lambda: self.opensite("https://github.com/EpixZone/EpixNet")),
-            (_["Report bug/request feature"], lambda: self.opensite("https://github.com/EpixZone/EpixNet/issues")),
-            "--",
-            (_["!Open EpixNet"], lambda: self.opensite("http://%s:%s/%s" % (ui_ip, config.ui_port, config.homepage))),
-            "--",
-            (_["Quit"], self.quit),
-        ]
-
-        if not notificationicon.hasConsole():
-            del icon.items[3]
-
-        icon.clicked = lambda: self.opensite("http://%s:%s/%s" % (ui_ip, config.ui_port, config.homepage))
         self.quit_servers_event = gevent.threadpool.ThreadResult(
             lambda res: gevent.spawn_later(0.1, self.quitServers), gevent.threadpool.get_hub(), lambda: True
         )  # Fix gevent thread switch error
-        gevent.threadpool.start_new_thread(icon._run, ())  # Start in real thread (not gevent compatible)
+
+        # Run pystray in a real thread (not gevent compatible)
+        gevent.threadpool.start_new_thread(self.icon.run, ())
         super(ActionsPlugin, self).main()
-        icon._die = True
+        try:
+            self.icon.stop()
+        except Exception:
+            pass
+
+    def _on_quit(self, icon, item):
+        self.icon.stop()
+        self.quit_servers_event.set(True)
+
+    def _on_toggle_console(self, icon, item):
+        if self.console:
+            _hide_console()
+            self.console = False
+        else:
+            _show_console()
+            self.console = True
+
+    def _on_toggle_autorun(self, icon, item):
+        if self.isAutorunEnabled():
+            os.unlink(self.getAutorunPath())
+        else:
+            open(self.getAutorunPath(), "wb").write(self.formatAutorun().encode("utf8"))
 
     def quit(self):
-        self.icon.die()
-        self.quit_servers_event.set(True)
+        self._on_quit(None, None)
 
     def quitServers(self):
         self.main.ui_server.stop()
@@ -85,8 +205,15 @@ class ActionsPlugin(object):
         import webbrowser
         webbrowser.open(url, new=0)
 
+    def announce(self, message, title="EpixNet"):
+        """Show an OS notification toast via the tray icon."""
+        try:
+            self.icon.notify(message, title)
+        except Exception as err:
+            print("Trayicon announce error: %s" % err)
+
     def titleIp(self):
-        title = "!IP: %s " % ", ".join(self.main.file_server.ip_external_list)
+        title = "IP: %s " % ", ".join(self.main.file_server.ip_external_list)
         if any(self.main.file_server.port_opened):
             title += _["(active)"]
         else:
@@ -104,23 +231,11 @@ class ActionsPlugin(object):
         )
         return title
 
-    def titleConsole(self):
-        translate = _["Show console window"]
-        if self.console:
-            return "+" + translate
-        else:
-            return translate
-
-    def toggleConsole(self):
-        if self.console:
-            notificationicon.hideConsole()
-            self.console = False
-        else:
-            notificationicon.showConsole()
-            self.console = True
-
     def getAutorunPath(self):
-        return "%s\\epixnet.cmd" % winfolders.get(winfolders.STARTUP)
+        startup = _get_startup_folder()
+        if not startup:
+            return None
+        return "%s\\epixnet.cmd" % startup
 
     def formatAutorun(self):
         args = sys.argv[:]
@@ -154,17 +269,6 @@ class ActionsPlugin(object):
 
     def isAutorunEnabled(self):
         path = self.getAutorunPath()
+        if not path:
+            return False
         return os.path.isfile(path) and open(path, "rb").read().decode("utf8") == self.formatAutorun()
-
-    def titleAutorun(self):
-        translate = _["Start EpixNet when Windows starts"]
-        if self.isAutorunEnabled():
-            return "+" + translate
-        else:
-            return translate
-
-    def toggleAutorun(self):
-        if self.isAutorunEnabled():
-            os.unlink(self.getAutorunPath())
-        else:
-            open(self.getAutorunPath(), "wb").write(self.formatAutorun().encode("utf8"))

--- a/plugins/Trayicon/__init__.py
+++ b/plugins/Trayicon/__init__.py
@@ -1,4 +1,1 @@
-import sys
-
-if sys.platform == 'win32':
-	from . import TrayiconPlugin
+from . import TrayiconPlugin

--- a/plugins/Trayicon/lib/notificationicon.py
+++ b/plugins/Trayicon/lib/notificationicon.py
@@ -521,17 +521,19 @@ class NotificationIcon(object):
         self.items = []
 
 
-    def _bubble(self, iconinfo):
+    def _bubble(self):
         if self._info_bubble:
             info_bubble = self._info_bubble
             self._info_bubble = None
-            message = str(self._info_bubble)
-            iconinfo.uFlags |= NIF_INFO
-            iconinfo.szInfo = message
-            iconinfo.szInfoTitle = message
-            iconinfo.dwInfoFlags = NIIF_INFO
-            iconinfo.union.uTimeout = 10000
-            Shell_NotifyIcon(NIM_MODIFY, ctypes.pointer(iconinfo))
+            title = str(info_bubble[0]) if isinstance(info_bubble, tuple) else "EpixNet"
+            message = str(info_bubble[1]) if isinstance(info_bubble, tuple) else str(info_bubble)
+            self.iconinfo.uFlags |= NIF_INFO
+            self.iconinfo.szInfo = message
+            self.iconinfo.szInfoTitle = title
+            self.iconinfo.dwInfoFlags = NIIF_INFO
+            self.iconinfo.union.uTimeout = 10000
+            Shell_NotifyIcon(NIM_MODIFY, ctypes.pointer(self.iconinfo))
+            self.iconinfo.uFlags &= ~NIF_INFO
 
 
     def _run(self):
@@ -644,6 +646,7 @@ class NotificationIcon(object):
             if not any(thread.getName() == 'MainThread' and thread.isAlive()
                        for thread in threading.enumerate()):
                 self._die = True
+            self._bubble()
         elif msg == WM_MENUCOMMAND and lParam == WM_LBUTTONUP:
             self.clicked()
         elif msg == WM_MENUCOMMAND and lParam == WM_RBUTTONUP:
@@ -676,8 +679,11 @@ class NotificationIcon(object):
             pass
 
 
-    def announce(self, text):
-        self._info_bubble = text
+    def announce(self, text, title=None):
+        if title:
+            self._info_bubble = (title, text)
+        else:
+            self._info_bubble = text
 
 
 def hideConsole():

--- a/plugins/Trayicon/plugin_info.json
+++ b/plugins/Trayicon/plugin_info.json
@@ -1,5 +1,5 @@
 {
 	"name": "Trayicon",
-	"description": "Icon for system tray. (Windows only)",
+	"description": "System tray icon with menu and notifications. (Windows, macOS, Linux)",
 	"default": "enabled"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ mock>=5.0.0
 bech32>=1.2.0
 pycryptodome>=3.20.0
 cryptography>=41.0.0
+pystray>=0.19.0
+Pillow>=10.0.0


### PR DESCRIPTION
This pull request introduces a comprehensive notification system to the `Notification` plugin, including both backend logic and frontend UI integration. The main changes add notification querying, mute/dismiss functionality, and a notification badge UI component that displays the number of unread notifications and updates in real time.

**Backend features and API:**

* Added `NotificationPlugin.py` implementing notification subscription management, querying notification counts, mute/unmute (global and per-site), and dismiss functionality, all exposed via websocket actions.
* Registered the plugin in `__init__.py` for automatic loading.

**Frontend UI integration:**

* Introduced `Notification.js` and `Notification.css` (also merged into `all.js` and `all.css`), which add a notification badge to the UI, poll for updates, and handle mute status and tooltips. 
* The badge updates in real time, shows the total count of unread notifications, and supports tooltips with per-site breakdowns. 
**Styling:**

* Added CSS for the notification badge, including positioning, colors, and a pop animation for visual feedback.

These changes together provide a full-stack notification system, enabling users to see and manage notifications directly from the UI.