### PR TITLE
fix: spawn download in background for immediate return and user feedback

### DIFF
--- a/src/Site/SiteManager.py
+++ b/src/Site/SiteManager.py
@@ -188,7 +188,9 @@ class SiteManager(object):
             site.settings["serving"] = True
         site.saveSettings()
         if all_file:  # Also download user files on first sync
-            site.download(check_size=True, blind_includes=True)
+            # Spawn download in background so callers (e.g. actionWrapper) can return
+            # immediately and the loading screen + progress bar are visible to the user.
+            gevent.spawn(site.download, check_size=True, blind_includes=True)
         return site
 
     # Return or create site and start download site files

--- a/src/Ui/media/Wrapper.css
+++ b/src/Ui/media/Wrapper.css
@@ -729,9 +729,8 @@ a {
 	z-index: 100;
 	top: 0;
 	left: 0;
-	transform: scaleX(0);
 	transform-origin: 0% 0%;
-	transform: translate3d(0, 0, 0);
+	transform: scaleX(0) translate3d(0, 0, 0);
 	height: 2px;
 	transition: transform 1s, opacity 1s;
 	display: none;


### PR DESCRIPTION
This pull request introduces improvements to both the backend and frontend to enhance user experience and code efficiency. The backend now spawns the site download process in the background, ensuring that the UI remains responsive and displays progress feedback to the user. On the frontend, minor CSS adjustments have been made to streamline the transform property for better maintainability.

**Backend improvements:**

* The `add` method in `SiteManager.py` now spawns the `site.download` process in the background using `gevent.spawn`, allowing the UI to show a loading screen and progress bar without waiting for the download to finish.

**Frontend/CSS adjustments:**

* Combined the `scaleX(0)` and `translate3d(0, 0, 0)` transforms into a single `transform` property in `Wrapper.css` for cleaner and more maintainable code.