### PR TITLE
fix: update regex for query part modification to handle multilines

### DIFF
--- a/plugins/Newsfeed/NewsfeedPlugin.py
+++ b/plugins/Newsfeed/NewsfeedPlugin.py
@@ -77,7 +77,7 @@ class UiWebsocketPlugin(object):
                             else:
                                 where = " WHERE %s > strftime('%%s', 'now', '-%s day')" % (date_field, day_limit)
                                 if "WHERE" in query_part:
-                                    query_part = re.sub("WHERE (.*?)(?=$| GROUP BY)", where+" AND (\\1)", query_part)
+                                    query_part = re.sub(r"WHERE (.*?)(?=$| GROUP BY)", where + r" AND (\1)", query_part, flags=re.DOTALL)
                                 else:
                                     query_part += where
                         query_parts[i] = query_part


### PR DESCRIPTION
This pull request makes a minor improvement to the regular expression used in the `actionFeedQuery` method of `NewsfeedPlugin.py`. The change adds the `re.DOTALL` flag to ensure that the regular expression matches across multiple lines, making the query modification more robust.

- Improved the regular expression substitution in `actionFeedQuery` to use the `re.DOTALL` flag, allowing multi-line matches when updating the SQL `WHERE` clause.