### PR TITLE
Update deprecated underscore CLI flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,10 @@ python epixnet.py
 ```cmd
 # Install Tor Browser or standalone Tor
 # Run EpixNet with Tor proxy
-python epixnet.py --tor_proxy 127.0.0.1:9150 --tor_controller 127.0.0.1:9151
+python epixnet.py --tor-proxy 127.0.0.1:9150 --tor-controller 127.0.0.1:9151
 
 # For full Tor anonymity
-python epixnet.py --tor_proxy 127.0.0.1:9150 --tor_controller 127.0.0.1:9151 --tor always
+python epixnet.py --tor-proxy 127.0.0.1:9150 --tor-controller 127.0.0.1:9151 --tor always
 ```
 
 ## Configuration
@@ -233,7 +233,7 @@ python epixnet.py --tor_proxy 127.0.0.1:9150 --tor_controller 127.0.0.1:9151 --t
 python3 epixnet.py
 
 # Custom port
-python3 epixnet.py --ui_port 42222
+python3 epixnet.py --ui-port 42222
 
 # Enable Tor
 python3 epixnet.py --tor always
@@ -242,7 +242,7 @@ python3 epixnet.py --tor always
 python3 epixnet.py --offline
 
 # Custom data directory
-python3 epixnet.py --data_dir /path/to/data
+python3 epixnet.py --data-dir /path/to/data
 
 # Debug mode
 python3 epixnet.py --debug


### PR DESCRIPTION
## Summary

Updates the README to use the new dash-style CLI flags, eliminating deprecation warnings emitted by `Config.fixArgs` when users follow the documented examples.

## Motivation

Running EpixNet with the flags as documented currently produces warnings such as:
```
WARNING: using deprecated flag in command line: --tor_controller should be --tor-controller
WARNING: using deprecated flag in command line: --tor_proxy should be --tor-proxy
Support for deprecated flags might be removed in the future
```

Since support for the underscore variants may be removed in the future, the documentation should steer users toward the supported syntax.

## Changes

Replaced underscore flags with their dashed equivalents in `README.md`:

- `--tor_proxy` → `--tor-proxy`
- `--tor_controller` → `--tor-controller`
- `--ui_port` → `--ui-port`
- `--data_dir` → `--data-dir`

## Notes

- Documentation-only change; no code or behavior is affected.
- The deprecated flags still work at runtime, so this is non-breaking for existing users.
