### PR TITLE
docs(readme): add Quick Start jump block, label OS-specific install sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,20 @@ EpixNet is a Python-based implementation of a decentralized web platform where:
 
 ## Quick Start
 
-### Prerequisites
+> [!NOTE]
+> **Jump to**
+>
+> - **Installation on Linux:** [manual](#linux-installation) | [Docker](#docker-installation) | [automated - bash script](#convenience-scripts)
+> - **Installation on Windows:** [manual](#windows-installation)
+> - **Post-installation:** [first site](#creating-your-first-site) | [configuration](#configuration) | [usage](#usage)
+
+### Linux Prerequisites
 
 - Python 3.8 or higher
 - Git (for cloning the repository)
 - Basic development tools (compiler, etc.)
 
-### Installation
+### Linux Installation
 
 1. **Clone the repository**:
 


### PR DESCRIPTION
## Summary

- Adds a GitHub `> [!NOTE]` "Jump to" block at the top of **Quick Start** with anchored links to the major install paths (Linux manual / Docker / automated script, Windows) and post-install sections (first site, configuration, usage).
- Renames `### Prerequisites` → `### Linux Prerequisites` and `### Installation` → `### Linux Installation` so they parallel `### Windows Installation` and the jump anchors are unambiguous.

## Why

[#29](https://github.com/EpixZone/EpixNet/pull/29) proposed the same navigation improvement, which is a good idea. This PR keeps that improvement while addressing the structural issues raised in review there:

- **Heading hierarchy preserved.** All H3 subsections under `## Quick Start` stay at H3 (no skip from H2 → H4). Distros and Docker sub-options remain at H4 as before.
- **No content lost.** "Creating Your First Site" walkthrough is kept intact (it contained the dashboard URL, new-site flow, and file-location explanation that weren't actually duplicated elsewhere).
- **Anchors verified.** All six Jump-to targets resolve: `#linux-installation`, `#docker-installation`, `#convenience-scripts`, `#windows-installation`, `#creating-your-first-site`, `#configuration`, `#usage`.

## Test plan

- [x] `grep -n "^#" README.md` shows continuous H2 → H3 → H4 hierarchy in Quick Start.
- [x] Every Jump-to anchor maps to an existing heading.
- [x] Render preview on GitHub shows the `[!NOTE]` callout correctly.

Credit to @slrslr ([#29](https://github.com/EpixZone/EpixNet/pull/29)) for the navigation idea.