### PR TITLE
docs(readme): correct DHT support claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ EpixNet is a Python-based implementation of a decentralized web platform where:
 - **Cryptographic authentication**: Password-less authorization using private/public key pairs
 - **Real-time synchronization**: Live updates across all peers when content changes
 - **Built-in database**: P2P synchronized SQLite database for dynamic content
+- **DHT peer discovery**: Trackerless peer discovery over the BitTorrent mainline DHT (enabled by default)
 - **Tor integration**: Full support for .onion hidden services (including onion-v3)
 - **Offline capability**: Access cached sites even without internet connection
 - **Clone protection**: One-click site cloning and forking
@@ -299,7 +300,6 @@ We welcome contributions! Here's how you can help:
 
 ### Current Limitations
 
-- No DHT support (relies on BitTorrent trackers)
 - No I2P integration
 - Limited spam protection mechanisms
 - No built-in encryption for local storage


### PR DESCRIPTION
## Summary

Fixes #28. The README's `### Current Limitations` section claimed "No DHT support (relies on BitTorrent trackers)", but DHT is fully implemented and enabled by default.

## Verification

- [`src/Config.py:443`](https://github.com/EpixZone/EpixNet/blob/main/src/Config.py#L443) — `--dht ... default=True`
- [`src/DHT/DHTServer.py`](https://github.com/EpixZone/EpixNet/blob/main/src/DHT/DHTServer.py) — async DHT server on `aiobtdht`, started from `Actions.initDHT()`
- [`src/Site/SiteAnnouncer.py:183`](https://github.com/EpixZone/EpixNet/blob/main/src/Site/SiteAnnouncer.py#L183) — `announceDHT()` runs alongside tracker announces; discovered peers tagged `source='dht'`
- [`src/DHT/DHTServer.py:90-96`](https://github.com/EpixZone/EpixNet/blob/main/src/DHT/DHTServer.py#L90-L96) — hardcoded mainline DHT bootstrap routers, so DHT works on first launch even with no trackers configured

## Changes

- Removes `- No DHT support (relies on BitTorrent trackers)` from `### Current Limitations`
- Adds `- **DHT peer discovery**: Trackerless peer discovery over the BitTorrent mainline DHT (enabled by default)` to `## Core Features`

## Other Current Limitations bullets — verified before leaving them alone

- **No I2P integration**: confirmed — no `I2P` references in `src/` or `plugins/`
- **Limited spam protection**: fair — `RateLimit` covers publish (30s) and file requests with `bad_actions` escalation, plus `--lax-cert-check`, but it's not a robust anti-spam system
- **No built-in encryption for local storage**: confirmed — `CryptMessage` plugin is ECIES for messaging (Epix Mail), not at-rest disk encryption; on-disk site data is plaintext

## Test plan

- [x] Diff is +1/-1, scoped to README
- [x] `grep -i DHT README.md` confirms no stale "No DHT" claim remains

Credit to @slrslr for catching this in #28.