### PR TITLE
fix(trayicon): skip tray init on headless Linux/BSD instead of crashing

### DIFF
--- a/plugins/Trayicon/TrayiconPlugin.py
+++ b/plugins/Trayicon/TrayiconPlugin.py
@@ -62,12 +62,31 @@ def _get_startup_folder():
 class ActionsPlugin(object):
 
     def main(self):
+        # On Linux/BSD pystray's _xorg backend opens an X11 connection at
+        # import time, which raises Xlib.error.DisplayNameError("") on
+        # headless boxes (SSH without forwarding, servers, containers, CI).
+        # Skip the tray icon up-front instead of crashing startup.
+        if sys.platform not in ("win32", "darwin"):
+            if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+                print("Trayicon plugin: no display detected (DISPLAY/WAYLAND_DISPLAY unset), skipping tray icon.")
+                super(ActionsPlugin, self).main()
+                return
+
         try:
             import pystray
             import pystray._base
             from PIL import Image
         except ImportError as err:
             print("Trayicon plugin: pystray or Pillow not installed (%s), skipping tray icon." % err)
+            super(ActionsPlugin, self).main()
+            return
+        except Exception as err:
+            # pystray's backend selection runs at import time and can raise
+            # backend-specific errors (e.g. Xlib.error.DisplayNameError on
+            # X11 systems, AppKit errors on broken macOS installs). Treat
+            # any import-time failure as "tray unavailable" rather than
+            # crashing the whole daemon.
+            print("Trayicon plugin: failed to initialize tray backend (%s), skipping tray icon." % err)
             super(ActionsPlugin, self).main()
             return
 


### PR DESCRIPTION
## Summary

Fixes #34. On a headless Linux box (server, SSH without X forwarding, container, CI), startup crashes with `Xlib.error.DisplayNameError: Bad display name ""` and EpixNet refuses to run.

## Root cause

[`plugins/Trayicon/TrayiconPlugin.py:66`](https://github.com/EpixZone/EpixNet/blob/main/plugins/Trayicon/TrayiconPlugin.py#L66) imports `pystray` inside a `try/except ImportError`. On Linux, pystray's `__init__.py` selects the `_xorg` backend at import time, which calls `Xlib.display.Display()`. With no `$DISPLAY` set, that raises `Xlib.error.DisplayNameError` — not an `ImportError` — so the guard misses it and the unhandled exception aborts `actions.main()`.

The Trayicon plugin is `"default": "enabled"` ([plugin_info.json](https://github.com/EpixZone/EpixNet/blob/main/plugins/Trayicon/plugin_info.json)), so every headless Linux user hits this on first run.

## Fix

Two layers of defense in [`TrayiconPlugin.py`](plugins/Trayicon/TrayiconPlugin.py):

1. **Pre-check on Linux/BSD:** if neither `DISPLAY` nor `WAYLAND_DISPLAY` is set, log "no display detected" and continue startup without the tray icon. Avoids even attempting the import, so the user sees a clean message instead of a traceback.
2. **Broaden the import guard:** catch `Exception` (in addition to `ImportError`) so backend-init failures from any platform (X11 connection refused, future Wayland backends, broken macOS AppKit) degrade gracefully to "tray unavailable" instead of crashing.

`super().main()` is called in both branches, so the rest of EpixNet boots normally.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('plugins/Trayicon/TrayiconPlugin.py').read())"` — syntax OK
- [ ] Reproduce: on a headless Linux box, `unset DISPLAY && python3 epixnet.py` — verify clean "no display detected" log and successful boot
- [ ] On a normal Linux desktop with `$DISPLAY` set, verify tray icon still appears
- [ ] On Windows / macOS, verify behavior unchanged (pre-check is gated by `sys.platform`)

## Workaround for affected users until merged

Rename `plugins/Trayicon` → `plugins/disabled-Trayicon` to disable the plugin.