### PR TITLE
fix(config): accept 'linux' platform string in getStartDir

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -245,7 +245,7 @@ class Config:
             path = MACOSX_DIR
         elif self.platform == 'windows':
             path = WINDOWS_DIR
-        elif self.platform in ('libredesktop', 'Linux'):
+        elif self.platform in ('libredesktop', 'Linux', 'linux'):
             path = LIBREDESKTOP_DIR
         else:
             raise RuntimeError(f'UNKNOWN PLATFORM: {self.platform}. Something must have went terribly wrong!')


### PR DESCRIPTION
## Summary

Fixes #33. The official Linux PyInstaller release binary crashes during startup with:

```
RuntimeError: UNKNOWN PLATFORM: linux. Something must have went terribly wrong!
```

## Root cause

The Linux release workflow runs `build.py --platform=linux` ([.github/workflows/build-installers.yml:226](https://github.com/EpixZone/EpixNet/blob/main/.github/workflows/build-installers.yml#L226)), which writes `platform = 'linux'` (lowercase) into `src/Build.py`. But [`Config.getStartDir()`](https://github.com/EpixZone/EpixNet/blob/main/src/Config.py#L248) only accepted `'libredesktop'` or `'Linux'` (capitalized) for the Linux branch — `'linux'` fell through to the `else: raise RuntimeError(...)` clause.

Source installs were unaffected because they set `self.platform = 'source'` ([Config.py:52](https://github.com/EpixZone/EpixNet/blob/main/src/Config.py#L52)), which is handled separately. **Only the bundled Linux release tarball** (`EpixNet-linux-x64.tar.gz` from GitHub Releases) hits this.

## Fix

One-line change in [`src/Config.py:248`](src/Config.py#L248): add `'linux'` to the accepted tuple.

```diff
-        elif self.platform in ('libredesktop', 'Linux'):
+        elif self.platform in ('libredesktop', 'Linux', 'linux'):
```

Kept `'libredesktop'` and `'Linux'` for backwards compatibility with any out-of-tree builds.

## Why this side and not the CI side

Could equally be fixed by changing the workflow to `--platform=libredesktop`, but accepting `'linux'` in Config is preferable:

- `'linux'` is the conventional string (matches `platform.system().lower()`, `sys.platform`, PyInstaller's `--target-platform`)
- `'libredesktop'` is an obscure legacy term
- Future build scripts/wrappers can use the obvious value without remembering the magic string

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('src/Config.py').read())"` — syntax OK
- [ ] Build the Linux PyInstaller artifact (`python build.py --type=installer --platform=linux && pyinstaller epixnet.spec --distpath dist/linux`) and verify `./dist/linux/EpixNet/EpixNet` starts and creates `~/.local/share/EpixNet/`
- [ ] Verify source install (`python3 epixnet.py`) still works — should be unaffected since `platform = 'source'` takes a different branch

## Severity note

This bug means every user who downloads `EpixNet-linux-x64.tar.gz` from GitHub Releases hits this on first launch, regardless of distro or display setup. Worth flagging for a point release once merged.