### PR TITLE
Allow adding new sites - Multiuser Plugin

### DIFF
--- a/plugins/disabled-Multiuser/MULTIUSER_README.md
+++ b/plugins/disabled-Multiuser/MULTIUSER_README.md
@@ -1,0 +1,16 @@
+# Multiuser Plugin
+
+**Main Features:**  
+- Mode settings: access the entire network, or allow only listed sites.  
+- Adding existing sites can be allowed or blocked (`multiuser_no_new_sites`).  
+  - `True` → adding new sites **allowed** (default)  
+  - `False` → adding new sites not allowed **blocked**, in which case the user receives the following **error message**:  
+    ```
+    Not Found
+    Adding new sites disabled on this proxy
+    ```
+- Users listed in `local_master_addresses` can **always add sites.**.  
+
+**Configuration and Editing:**  
+- Open the **`MultiuserPlugin.py`** file in Notepad++ or any other text editor.  
+- Change the `config.multiuser_no_new_sites` value according to your desired behavior.

--- a/plugins/disabled-Multiuser/MultiuserPlugin.py
+++ b/plugins/disabled-Multiuser/MultiuserPlugin.py
@@ -50,12 +50,12 @@ class UiRequestPlugin(object):
         else:
             user = None
 
-        # Disable new site creation if --multiuser_no_new_sites enabled
+         # Disable new site creation if --multiuser_no_new_sites enabled "Adding new sites disabled on this proxy", details=True or False turn it False if You want block users to add new websites to your server!
         if config.multiuser_no_new_sites:
             path_parts = self.parsePath(path)
             if not self.server.site_manager.get(match.group("address")) and (not user or user.master_address not in local_master_addresses):
                 self.sendHeader(404)
-                return self.formatError("Not Found", "Adding new sites disabled on this proxy", details=False)
+                return self.formatError("Not Found", "Adding new sites disabled on this proxy", details=True)
 
         if user_created:
             if not extra_headers:


### PR DESCRIPTION
Allow adding new sites by default if the NoNewSites plugin is not enabled.

This restores an original ZeroNet feature that allowed browsing the network from the clearnet and helped with seeding newly created sites.

Additionally, this could be extended with a 24-hour retention option, where user-added content is stored for 24 hours and then automatically deleted, similar to temporary content pinning approaches used in systems like IPFS. In this model, each user can only see the content they have added themselves, and content added by other users is not publicly visible on the dashboard, meaning it is not exposed to other users or shown in the global/server-wide view.