### PR TITLE
docs(readme): trim duplicated Quick Start content, fold details into Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ EpixNet is a Python-based implementation of a decentralized web platform where:
 >
 > - **Installation on Linux:** [manual](#linux-installation) | [Docker](#docker-installation) | [automated - bash script](#convenience-scripts)
 > - **Installation on Windows:** [manual](#windows-installation)
-> - **Post-installation:** [first site](#creating-your-first-site) | [configuration](#configuration) | [usage](#usage)
+> - **Post-installation:** [configuration](#configuration) | [usage](#usage)
 
 ### Linux Prerequisites
 
@@ -76,17 +76,6 @@ EpixNet is a Python-based implementation of a decentralized web platform where:
    ```bash
    python3 epixnet.py
    ```
-
-5. **Access the dashboard**:
-   Open your browser and navigate to: `http://127.0.0.1:42222/`
-
-### Creating Your First Site
-
-1. Visit the EpixNet dashboard at `http://127.0.0.1:42222/`
-2. Click **⋮** > **"Create new, empty site"**
-3. You'll be redirected to your new site that only you can modify
-4. Find your site files in the `data/[your_site_address]` directory
-5. Edit your content, then drag the "0" button left and click **"Sign and publish"**
 
 ### System Dependencies for Source Installation
 
@@ -270,10 +259,11 @@ EpixNet creates a `epixnet.conf` file in your data directory where you can set p
 
 ### Site Management
 
-- **Create new site**: Dashboard → ⋮ → "Create new, empty site"
+- **Create new site**: Dashboard → ⋮ → "Create new, empty site" — you become the sole owner and only you can modify it
 - **Clone existing site**: Visit site → Clone button
 - **Manage sites**: Dashboard shows all your sites and visited sites
 - **Site files**: Located in `data/{site_address}/` directory
+- **Publish changes**: Drag the site "0" button left and click "Sign and publish"
 
 ## Development
 


### PR DESCRIPTION
## Summary

Supersedes #44. @slrslr correctly observed that step 5 of Linux Installation ("Access the dashboard") and the "Creating Your First Site" walkthrough duplicate content already covered in `## Usage` below. This PR applies that removal and ties up two loose ends raised in review.

## Changes

### Same as #44
- Removes step 5 ("Access the dashboard") from Linux Installation
- Removes the entire `### Creating Your First Site` walkthrough
- Adds a "Publish changes" bullet to Site Management

### Additional fixes
1. **Preserve sole-ownership detail.** The deleted step 3 said *"you'll be redirected to your new site that **only you can modify**"* — the one piece of information from the walkthrough not duplicated elsewhere. Folded into the Site Management bullet:
   ```diff
   - - **Create new site**: Dashboard → ⋮ → "Create new, empty site"
   + - **Create new site**: Dashboard → ⋮ → "Create new, empty site" — you become the sole owner and only you can modify it
   ```

2. **Drop the now-stale jump-to anchor.** The jump block added in #36 included `[first site](#creating-your-first-site)`. With the section gone, that anchor breaks. Updated to:
   ```diff
   - > - **Post-installation:** [first site](#creating-your-first-site) | [configuration](#configuration) | [usage](#usage)
   + > - **Post-installation:** [configuration](#configuration) | [usage](#usage)
   ```

## Verification

- [x] `-13/+3` net, scoped to README.md
- [x] All remaining jump-to anchors in the `> [!NOTE]` block still resolve (`#linux-installation`, `#docker-installation`, `#convenience-scripts`, `#windows-installation`, `#configuration`, `#usage`)
- [x] No information from the deleted walkthrough is lost — covered either by Usage/Site Management or folded into the new bullets above

## Credit

@slrslr in #44 for the scope-reduction observation.