### PR TITLE
docs(multiuser): add README documenting the plugin and its CLI flags

### DIFF
--- a/plugins/disabled-Multiuser/README.md
+++ b/plugins/disabled-Multiuser/README.md
@@ -1,0 +1,124 @@
+# Multiuser Plugin
+
+Turns an EpixNet instance into a multi-user proxy gateway. Each visitor is
+assigned a cookie-backed identity automatically; admins log in with their
+existing master seed.
+
+By default this plugin is **disabled** (the directory is named
+`disabled-Multiuser`). Enable it only if you are deliberately running a
+public gateway. For normal desktop use, leave it disabled.
+
+## Enabling the plugin
+
+Rename the directory so the plugin manager loads it:
+
+```bash
+mv plugins/disabled-Multiuser plugins/Multiuser
+```
+
+Restart EpixNet. The plugin will register two new CLI flags
+(`--multiuser-local`, `--multiuser-no-new-sites`).
+
+To disable again, rename back to `plugins/disabled-Multiuser`.
+
+## Operating modes
+
+The plugin's behaviour for any given request depends on whether the visitor
+is a **proxy user** (cookie-backed anonymous identity) or an **admin**.
+Admin status is granted to:
+
+- Any visitor whose `master_address` cookie matches an entry in
+  `<data-dir>/private/users.json` (the local user file, populated by your
+  own client), **or**
+- All visitors, if `--multiuser-local` is passed.
+
+Proxy users have access to most browsing features but are blocked from
+admin-only actions (decorated with `@flag.no_multiuser` in the source).
+Attempts produce the notification:
+
+```text
+This function (<cmd>) is disabled on this proxy!
+```
+
+## CLI flags
+
+### `--multiuser-local`
+
+Run the plugin in **local mode**: every visitor is treated as an admin and
+user objects are persisted to disk. Use this when you want the multi-user
+UI features (login form, user-switching, master-seed prompts) on your own
+machine without locking yourself out of admin functions.
+
+```bash
+python3 epixnet.py --multiuser-local
+```
+
+Do not use this in production. The flag's own help text describes it as
+"unsafe Ui functions".
+
+### `--multiuser-no-new-sites`
+
+Block proxy users from adding sites the gateway hasn't already loaded.
+Admins (per the rules above) can still add sites.
+
+```bash
+python3 epixnet.py --multiuser-no-new-sites
+```
+
+The flag is a boolean (`store_true`). It is **off by default** — adding
+new sites is allowed unless you pass this flag. Passing the flag without a
+value is correct; do not pass `enabled`, `true`, `1`, etc.
+
+When the flag is on and a proxy user visits an unknown site address, the
+gateway returns:
+
+```text
+Not Found
+Adding new sites disabled on this proxy
+```
+
+The flag can also be set persistently in `epixnet.conf`:
+
+```ini
+[global]
+multiuser_no_new_sites = True
+```
+
+### Combining the flags
+
+For a public gateway where you (the operator) want to keep admin rights:
+
+```bash
+python3 epixnet.py --multiuser-local --multiuser-no-new-sites
+```
+
+This locks down site-adding for anonymous visitors while letting you add
+and manage sites normally.
+
+## Logging in as an existing master address
+
+If you want to use your existing master seed (so you appear as admin via
+`users.json` rather than via `--multiuser-local`), Multiuser exposes a
+`userLoginForm` websocket action. The simplest way to invoke it from a
+clean session:
+
+1. Clear the `master_address` cookie for your EpixNet origin, or open the
+   dashboard in a private window.
+2. In the browser's JavaScript console (with the dashboard frame focused),
+   run:
+   ```js
+   epixframe.cmd("userLoginForm")
+   ```
+3. Paste the master seed from `<data-dir>/private/users.json` into the
+   prompt and submit. The cookie is updated and the page reloads.
+
+Some site UIs (e.g. Epix Talk) surface a "Connect xID" / Login button
+that calls the same action — once that flow is invoked you can paste the
+seed there instead of using the console.
+
+## Related
+
+- `NoNewSites` plugin (`plugins/disabled-NoNewSites/`) is a newer, simpler
+  way to lock down a public gateway. It also injects a "Public gateway —
+  read-only" banner. If you only need to block site additions and don't
+  want the full multi-user account system, enable `NoNewSites` instead.


### PR DESCRIPTION
## Summary

Adds `plugins/disabled-Multiuser/README.md` documenting the Multiuser plugin (public-gateway / multi-user proxy mode). The plugin has no documentation today; this PR fills that gap.

## Why now

@mx5kevin's #42 correctly identified that this plugin needs docs — that observation was the valuable part of the PR. The README content in #42 had several factual errors (inverted default values, "edit the Python file" instructions, etc.) so it was closed, but the underlying gap remained. This PR is a corrected version.

In live testing this evening:
- `--multiuser-no-new-sites enabled` produced no error — argparse silently ignored the `enabled` token because the flag is `store_true`. People will try to pass values; the README spells out that they shouldn't.
- Enabling the plugin without `--multiuser-local` caused the local operator to see "This function (serverErrors) is disabled on this proxy!" on admin actions — a confusing UX that's expected behavior, and now documented.
- The relationship to `NoNewSites` was unclear; the README now cross-references it as the simpler alternative for read-only gateways.

## What the README covers

- When to enable / disable the plugin (rename `disabled-Multiuser` ↔ `Multiuser`)
- The admin vs. proxy-user distinction and how admin status is decided (`users.json` membership or `--multiuser-local`)
- Both CLI flags with correct semantics:
  - `--multiuser-local`: every visitor is admin, users persisted to disk; "unsafe Ui functions" per the flag's own help text
  - `--multiuser-no-new-sites`: `store_true`, **off by default** (i.e. adding sites allowed by default), pass the flag bare with no value
  - `epixnet.conf` form for persistent configuration
  - Recommended combo for operators: `--multiuser-local --multiuser-no-new-sites`
- How to log in as an existing master address from a clean session (via the `userLoginForm` websocket action)
- Cross-reference to the newer `NoNewSites` plugin

## Verification

- [x] Confirmed `--multiuser-no-new-sites` is `store_true` ([MultiuserPlugin.py:276](plugins/disabled-Multiuser/MultiuserPlugin.py#L276))
- [x] Confirmed admin check is `not config.multiuser_local and self.user.master_address not in local_master_addresses` ([MultiuserPlugin.py:217](plugins/disabled-Multiuser/MultiuserPlugin.py#L217))
- [x] Confirmed `local_master_addresses` is loaded from `<data-dir>/private/users.json` ([MultiuserPlugin.py:19](plugins/disabled-Multiuser/MultiuserPlugin.py#L19))
- [x] Confirmed `userLoginForm` action exists ([MultiuserPlugin.py:197](plugins/disabled-Multiuser/MultiuserPlugin.py#L197))
- [x] Markdown lint warnings (MD040) addressed by tagging code blocks as `text`

## Credit

@mx5kevin in [#42](https://github.com/EpixZone/EpixNet/pull/42) for flagging the documentation gap.